### PR TITLE
Formatted reading list output as numbered string

### DIFF
--- a/bot/tests/test_utils.py
+++ b/bot/tests/test_utils.py
@@ -1,0 +1,11 @@
+from utils import utils
+
+def testNumberedStrIterable():
+    expected = '1. first\n2. second\n3. third'
+    exampleList1 = ['first', 'second', 'third']
+    exampleList2 = []
+    exampleTuple = ('first', 'second', 'third')
+    assert utils.numberedStrIterable(exampleList1) == expected
+    assert utils.numberedStrIterable(exampleList2) == ''
+    assert utils.numberedStrIterable(exampleTuple) == expected
+    

--- a/bot/utils/utils.py
+++ b/bot/utils/utils.py
@@ -1,0 +1,9 @@
+import typing
+
+def numberedStrIterable(strlist: typing.Union[list[str], tuple[str,...]]) -> str:
+    ans = ""
+    for i, s in enumerate(strlist):
+        ans +=  f"{i+1}. {s}"
+        if i != len(strlist) - 1:
+            ans +=  "\n"
+    return ans


### PR DESCRIPTION
# Problem
* The output from the $reading command was ugly and cluttered, so it would be better formatted as a numbered list
<img width="557" alt="Screenshot 2023-08-16 at 3 34 26 PM" src="https://github.com/mxmllnknz/bookclub/assets/43051599/04e04fee-9728-4a10-9eb6-c8d7c3a78746">

# Solution
* Create a utils library for these helper functions to make them as reusable as possible
<img width="536" alt="Screenshot 2023-08-16 at 3 33 41 PM" src="https://github.com/mxmllnknz/bookclub/assets/43051599/2319e74e-9900-4f5d-86fc-b8d5c7dbad85">
